### PR TITLE
Change getenv to shell-command for TRAMP-compatibility

### DIFF
--- a/slurm-mode.el
+++ b/slurm-mode.el
@@ -267,7 +267,7 @@ Manipulations of the jobs list:
 
   ;; Initialize user filter
   (if slurm-filter-user-at-start
-      (slurm-filter-user (getenv "USER"))
+      (slurm-filter-user (shell-command-to-string "echo -n $USER"))
     (slurm-filter-user ""))
 
   ;; Initialize partition filter


### PR DESCRIPTION
This worked better for me as I use the mode over TRAMP. Thanks for your consideration.

When using over TRAMP, (getenv "USER") seems to give the local user name.
(shell-command-to-string "echo -n $USER") gives the correct remote user name.