### PR TITLE
Add support for executing SLURM commands via SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ scripts.
 
 - `slurm-squeue-format`: the list of fields to display in the jobs list.
 
+- `slurm-remote-host`: Execute SLURM commands on this remote host
+  using SSH rather than executing them directly. See also
+  `slurm-remote-username` and `slurm-remote-ssh-cmd`.
+
+- `slurm-remote-username`: Username to use for SSHing to the remote
+  machine specified in `slurm-remote-host`."
+
+- `slurm-remote-ssh-cmd`: Command to use as SSH when executing SLURM commands on a
+  remote machine. Defaults to `ssh`.
+
 All these variables can be customized via `M-x customize-group RET slurm RET`.
 
 


### PR DESCRIPTION
This PR adds support for wrapping SLURM commands in SSH so that they are executed on a remote host. At least for me, this is more useful and convenient compared to only being able to use the mode locally on a cluster node.

I expect the code to be fairly self-explanatory, but please let me know if you have any questions.