### PR TITLE
Tramp support for multiple slurm servers

### DIFF
--- a/slurm-mode.el
+++ b/slurm-mode.el
@@ -163,7 +163,7 @@ cmd))
       (let ((result ""))
         (dolist (item list)
           (if (stringp item)
-              (setq result (concatenate 'string result item " "))))
+              (setq result (concat result item " "))))
         result)))
 
 (defvar slurm--buffer)
@@ -261,11 +261,11 @@ Assign it the new value VALUE."
   "Open a slurm-mode buffer to manage jobs."
   (interactive)
   (if (file-remote-p default-directory)
-      (setq slurm-remote-host (concatenate 'string "/ssh:" (file-remote-p default-directory 'host) ":" ";"))
+      (setq slurm-remote-host (concat "/ssh:" (file-remote-p default-directory 'host) ":" ";"))
     (setq slurm-remote-host nil))
 
   (if (file-remote-p default-directory)
-      (switch-to-buffer (get-buffer-create (concatenate 'string "slurm-" (file-remote-p default-directory 'host))))
+      (switch-to-buffer (get-buffer-create (concat "slurm-" (file-remote-p default-directory 'host))))
     (switch-to-buffer (get-buffer-create "slurm")))
   (if (eq major-mode 'slurm-mode)
       (slurm-refresh)
@@ -417,7 +417,7 @@ Schedule the following command to be executed after termination of the current o
     (slurm--set :old-position (max (line-number-at-pos) 8))
     (slurm--set :running-commands (slurm--get :command))
     (setq buffer-read-only nil)
-    (setq slurm-remote-host (concatenate 'string "/ssh:" (nth 1 (split-string (buffer-name) "-")) ":" ";"))
+    (setq slurm-remote-host (concat "/ssh:" (nth 1 (split-string (buffer-name) "-")) ":" ";"))
     (erase-buffer)
     (insert (format-time-string "%Y-%m-%d %H:%M:%S\n"))
     (when slurm-display-help
@@ -711,7 +711,7 @@ currently being displayed."
         (setq type  "array"
               jobid (match-string 1 jobid)))
 
-	(slurm--set :command `(("seff" ,jobid)))
+	(slurm--set :command `(("seff" ,jobid, "|" ,"sed" ,"-r" ,"s/[[:cntrl:]][[0-9]{1,3}m//g")))
         (slurm--set :jobid   jobid))
 	(setq mode-name "Slurm (seff details)")
 	(slurm--set :view 'slurm-seff)
@@ -877,7 +877,7 @@ Key bindings:
   (when (eq major-mode 'slurm-update-mode)
     (kill-buffer)
     (if (file-remote-p default-directory)
-       (switch-to-buffer (get-buffer-create (concatenate 'string "*slurm-*" (file-remote-p default-directory 'host))))
+       (switch-to-buffer (get-buffer-create (concat "*slurm-*" (file-remote-p default-directory 'host))))
      (switch-to-buffer (get-buffer-create "*slurm*")))
     ;(switch-to-buffer "*slurm*")
     (slurm-refresh)))

--- a/slurm-mode.el
+++ b/slurm-mode.el
@@ -103,7 +103,9 @@ is changed to ensure the new value is used wherever necessary."
   '((jobid      9 left)
     (jobname  20  right)
     (workdir  70  right)
-    (state  1  right))
+    (state  30  right)
+    (start 30 right)
+    (elapsed 30 right))
   "List of fields to display in the jobs list.
 
 Each entry in the list should be of the form:

--- a/slurm-mode.el
+++ b/slurm-mode.el
@@ -81,7 +81,7 @@ and `slurm-remote-ssh-cmd'."
 
 ;;;###autoload
 (defcustom slurm-squeue-format
-  '((jobid      9 right)
+  '((jobid      20 left)
     (partition  9 left)
     (name      37 left)
     (user       8 left)
@@ -690,6 +690,12 @@ currently being displayed."
   (when (eq major-mode 'slurm-mode)
     (when (slurm--in-view 'slurm-job-list)
       (let ((jobid  (slurm-job-id)))
+
+	(when (string-match "^\\([[:digit:]]+\\)_*"
+                               jobid)
+        (setq type  "array"
+              jobid (match-string 1 jobid)))
+
         (slurm--set :command `(("scontrol" "show" "job" ,jobid)))
         (slurm--set :jobid   jobid))
       (setq mode-name "Slurm (job details)")


### PR DESCRIPTION
Hi, 
This is one of the most useful packages for people like me who use servers to do most of their computations. There are two changes in this pull request. 
1. The slurm.el was not able to handle multiple servers automatically. There is a pull request https://github.com/ffevotte/slurm.el/pull/4#issue-325879582 to do it using ssh but it is not automatic. Moreover, if we need a password to log into the servers then this method will not work. However, borrowing from this idea, I replaced the `shell` command with `eshell` which works over tramp. So calling slurm command from tramp connected buffer will automatically handle the hostname and username. The only missing part is to create a separate `slurm-buffer` for each server (which can be implemented later as an improvement). 
2. Added `sacct` command to visualize the job history which is useful to keep track of failed/completed jobs.

Thanks,